### PR TITLE
Fix date change when the date and time pickers are used in combination 

### DIFF
--- a/Source/datepicker.js
+++ b/Source/datepicker.js
@@ -567,6 +567,8 @@ var DatePicker = new Class({
 					if (this.options.timePicker){
 						date.setDate(d.day);
 						date.setMonth(d.month);
+						this.d.setDate(d.day);
+						this.d.setMonth(d.month);
 						this.mode = 'time';
 						this.render('fade');
 					} else {


### PR DESCRIPTION
A simple fix for the date not being stored when the user selects a month and is about to be taken to the time picker. I haven't looked to see if this problem occurs with the year picker, but I hope this helps! Cheers.
