### PR TITLE
Parse date with the option format first

### DIFF
--- a/Source/Picker.Date.js
+++ b/Source/Picker.Date.js
@@ -115,7 +115,10 @@ this.DatePicker = Picker.Date = new Class({
 			}
 			this.date = new Date();
 			if (input){
-				var date = Date.parse(input.get('value'));
+				var date = Date.parse(input.get('value'),options.format);
+				if (date == null){
+					date = Date.parse(input.get('value'));
+				}
 				if (date == null || !date.isValid()){
 					var storeDate = input.retrieve('datepicker:value');
 					if (storeDate) date = Date.parse(storeDate);


### PR DESCRIPTION
Hello,

If my pull request on mootools-more git is accepted (https://github.com/brenard/mootools-more/commit/9bd784152aca157cce3b173a9d81f06a0973c20e), this change permit parsing date with the format options before testing other format. In particular case, it avoid parsing error. What do you think ?

Thanks,
