### PR TITLE
uk-UA Locale file incorrectly named en-US

### DIFF
--- a/Source/Locale.uk-UA.DatePicker.js
+++ b/Source/Locale.uk-UA.DatePicker.js
@@ -2,7 +2,7 @@
 ---
 name: Locale.uk-UA.DatePicker
 description: Ukrainian Language File for DatePicker
-authors: Arian Stolwijk, Jon Baker
+authors: Arian Stolwijk, Jon Baker, Artem Godlevskyy
 requires: [More/Locale]
 provides: Locale.uk-UA.DatePicker
 ...


### PR DESCRIPTION
Packager was compiling in the uk-UA Locale instead of the en-US, causing the timepicker to not have any text.  This fix re-names the uk-UA Locale file.
